### PR TITLE
Fix Canadian cell contact typo

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -28,7 +28,7 @@
 
   <ul>
       <li> email: <a href="mailto:jack&#064;&#098;&#101;&#100;&#097;&#046;&#099;&#097;%20(Jack%20Beda)?">jack&#064;&#098;&#101;&#100;&#097;&#046;&#099;&#097;</a></li>			<li> cell (UK): +44 (0) 7749 845057</li>
-      <li> cell (Canada): +1 (705) 313-9064 (Number only monitered when I am in Canada)</li>
+      <li> cell (Canada): +1 (705) 313-9064 (Number only monitored when I am in Canada)</li>
       <li> landline (UK): +44 (0) 131 608 0149 </li>
       <li> landline (Canada): +1 (705) 243-4679 or +1 (705) 876-9946;4</li>
       <li> instagram: <a href = "https://www.instagram.com/jfbeda/" target = "_blank"> @jfbeda </a> </li>


### PR DESCRIPTION
## Summary
- fix typo in Canadian cell phone line on contact page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0946719dc832e94cb51646ca825b4